### PR TITLE
Fix links

### DIFF
--- a/_includes/links-list.html
+++ b/_includes/links-list.html
@@ -5,5 +5,5 @@
   <li><a href="http://www.patreon.com/mcedit2">Donate via Patreon</a></li>
   <li><a href="/tools.html">Other tools</a></li>
   <li><a href="https://www.mcedit-unified.net/">MCEdit 1.x (legacy codebase)</a></li>
-  <li><a href="http://minecraft.net">Play Minecraft</a></li>
+  <li><a href="https://minecraft.net">Play Minecraft</a></li>
 </ul>

--- a/_includes/links-list.html
+++ b/_includes/links-list.html
@@ -4,6 +4,6 @@
   <li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=UZGWD6FFLCFJA&lc=US&item_name=MCEdit%2c%20a%20World%20Editor%20for%20Minecraft&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted">Donate via PayPal</a></li>
   <li><a href="http://www.patreon.com/mcedit2">Donate via Patreon</a></li>
   <li><a href="/tools.html">Other tools</a></li>
-  <li><a href="http://khroki.github.io/MCEdit-Unified/">MCEdit 1.x (legacy codebase)</a></li>
+  <li><a href="https://www.mcedit-unified.net/">MCEdit 1.x (legacy codebase)</a></li>
   <li><a href="http://minecraft.net">Play Minecraft</a></li>
 </ul>

--- a/tools.md
+++ b/tools.md
@@ -19,7 +19,7 @@ Here is a short list of external programs for Minecraft that I've used and can r
 
 Here are a few mods that can use MCEdit's .schematic files in some way.
 
-* [WorldEdit](http://www.enginehub.org/worldedit) - In-game world editor. Shares many features with MCEdit and has a few unique features of its own, including CraftScripts and mathematical function evaluation.
+* [WorldEdit](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1272389-worldedit-do-really-big-things-in-game-in-game-map) - In-game world editor. Shares many features with MCEdit and has a few unique features of its own, including CraftScripts and mathematical function evaluation.
 
 * [Schematica](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1285818-schematica) - Imports a .schematic file as a ghost outline for you to build yourself!
 


### PR DESCRIPTION
I was on the MCEdit 2.x website and tried to go to the MCEdit 1.x website, and noticed some links weren't working. I decided to fix those links in this pull request.

The WorldEdit link was broken (EngineHub was down) so I replaced it with the MinecraftForum page (because the SK89Q website was also down)

Also, I replaced HTTP with HTTPS (for links that are compatible) just in case.